### PR TITLE
Poll Experience: Pop Ups, Erroring, etc. 

### DIFF
--- a/plugins/nodebb-plugin-composer-polls/static/lib/composer-polls.js
+++ b/plugins/nodebb-plugin-composer-polls/static/lib/composer-polls.js
@@ -141,10 +141,24 @@ hooks.on('filter:composer.submit', (payload) => {
 			className: 'btn-secondary',
 		};
 
+		// Find the buttons.save section in openPollModal and replace it with:
 		buttons.save = {
 			label: saveLabel,
 			className: 'btn-primary',
-			callback: () => handleSave(dialog, uuid, postContainer, placeholders, { editLabel, removeSummaryLabel, allowNote }),
+			callback: function() {
+				// Return false immediately to prevent dialog from closing
+				handleSave(dialog, uuid, postContainer, placeholders, { 
+					editLabel, 
+					removeSummaryLabel, 
+					allowNote 
+				}).then((saved) => {
+					// Only close dialog manually if save was successful
+					if (saved) {
+						dialog.modal('hide');
+					}
+				});
+				return false;
+			},
 		};
 
 		const dialog = bootbox.dialog({


### PR DESCRIPTION
Issue:
https://github.com/CMU-313/NodeBB/issues/338

What:
- When user attempts to save poll without a poll type selected, should error but the user should not have to recreate the poll, the pop up should remain

Why:
- Important for the user experience otherwise all the fields entered go away when the pop up goes away. They very well make the same mistake 

How:
Uses the buttons.save handler to return false on handleSave immediately so the pop up does not close.

Testing:
Done through the UI, npm run lint, npm run test 

![PollTypeEmpty](https://github.com/user-attachments/assets/64011124-01df-4d6f-a2d3-ae0b66641bb9)
![PollOptionsEmpty](https://github.com/user-attachments/assets/ffcb117f-1fc5-440b-91e9-850b3699f8c1)
![PollClosingInvalid](https://github.com/user-attachments/assets/f6f9ed30-f460-4a47-9e8e-2b58b0f77d51)
